### PR TITLE
Always log request body for POST and PUT methods

### DIFF
--- a/lib/http_logger.rb
+++ b/lib/http_logger.rb
@@ -50,7 +50,7 @@ class HttpLogger
   ensure
     if require_logging?(http, request)
       log_request_url(http, request, start_time)
-      log_post_put_params(request)
+      log_request_body(request)
       log_request_headers(request)
       if defined?(response) && response
         log_response_code(response)
@@ -74,10 +74,13 @@ class HttpLogger
     end
   end
 
-  def log_post_put_params(request)
-    body = request.body
-    if body && !body.empty? && (request.is_a?(::Net::HTTP::Post) || request.is_a?(::Net::HTTP::Put))
-      log("Request body", truncate_body(body))
+  HTTP_METHODS_WITH_BODY = %w(POST PUT)
+  
+  def log_request_body(request)
+    if HTTP_METHODS_WITH_BODY.include?(request.method)
+      if (body = request.body) && !body.empty?
+        log("Request body", truncate_body(body))
+      end
     end
   end
 

--- a/spec/http_logger_spec.rb
+++ b/spec/http_logger_spec.rb
@@ -81,6 +81,18 @@ describe HttpLogger do
     it {should include("Request body")}
     it {should include("a=hello&b=1")}
   end
+  
+  describe "generic request" do
+    let(:request) do
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTPGenericRequest.new('PUT', true, true, uri.path)
+      request.body = "a=hello&b=1"
+      http.request(request)
+    end
+
+    it {should include("Request body")}
+    it {should include("a=hello&b=1")}
+  end
 
   context "with long response body" do
 


### PR DESCRIPTION
I tried HttpLogger with [Faraday](https://github.com/lostisland/faraday) using the Net::HTTP adapter. I noticed that the request body for POST and PUT requests were not being logged.

It turns out that Faraday uses the Net::HTTPGenericRequest class for all requests. (See https://github.com/lostisland/faraday/blob/master/lib/faraday/adapter/net_http.rb#L55).

This pull request makes sure the request body gets logged regardless of the specific class of the request object. For consistency, I also renamed the method from `log_post_put_params` to `log_request_body`.
