### PR TITLE
If we've already set the logger don't override it

### DIFF
--- a/lib/http_logger.rb
+++ b/lib/http_logger.rb
@@ -196,12 +196,12 @@ if defined?(Rails)
   if !Rails.respond_to?(:application) || (Rails.application && Rails.application.config)
     # Rails2
     Rails.configuration.after_initialize do
-      HttpLogger.logger = Rails.logger
+      HttpLogger.logger = Rails.logger unless HttpLogger.logger
     end
   elsif defined?(ActiveSupport) && ActiveSupport.respond_to?(:on_load)
     # Rails3
     ActiveSupport.on_load(:after_initialize) do
-      HttpLogger.logger = Rails.logger
+      HttpLogger.logger = Rails.logger unless HttpLogger.logger
     end
   end
 end


### PR DESCRIPTION
This enables us to configure the logger in a rails initializer, fixed #6
