### PR TITLE
Log body for GET requests

### DIFF
--- a/lib/http_logger.rb
+++ b/lib/http_logger.rb
@@ -1,5 +1,6 @@
 require 'net/http'
-require "uri"
+require 'uri'
+require 'set'
 
 # Usage:
 #
@@ -79,7 +80,7 @@ class HttpLogger
     end
   end
 
-  HTTP_METHODS_WITH_BODY = %w(POST PUT)
+  HTTP_METHODS_WITH_BODY = Set.new(%w(POST PUT GET))
   
   def log_request_body(request)
     if HTTP_METHODS_WITH_BODY.include?(request.method)


### PR DESCRIPTION
We've been using Elasticsearch in our Rails app via the Tire gem. We noticed that the request body for search API calls were not getting logged by HTTP Logger. It turns out that HTTP Logger does not log the request body for GET requests. Normally it's unusual for a GET request to have a body, but [Elasticsearch's search API](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html) actually does it this way. It's been quite annoying not being able to see the generated Elasticsearch query in the logs.

This pull requests enables logging the request body for GET requests.

I also turned `HTTP_METHODS_WITH_BODY` into a `Set`. After benchmarking, it turns out that `Set` is faster than  `Array` even for a tiny lookup array such as this.
