### PR TITLE
Use alias method chaining instead of prepend to be compatible with other gems

### DIFF
--- a/lib/http_logger.rb
+++ b/lib/http_logger.rb
@@ -190,18 +190,18 @@ class HttpLogger
   end
 end
 
-module NetHttpLogger
-  def request(request, body = nil, &block)
-    HttpLogger.perform(self, request, body) do
-      super(request, body, &block)
-    end
-  end
-end
-
 if defined?(::WebMock)
   WebMock::HttpLibAdapters::NetHttpAdapter.instance_variable_get("@webMockNetHTTP").prepend(NetHttpLogger)
 end
-Net::HTTP.prepend(NetHttpLogger)
+
+Net::HTTP.class_eval do
+  alias request_without_net_http_logger request
+  def request(request, body = nil, &block)
+    HttpLogger.perform(self, request, body) do
+      request_without_net_http_logger(request, body, &block)
+    end
+  end
+end
 
 if defined?(Rails)
 


### PR DESCRIPTION
I only updated the `Net::HTTP` prepend and left the Webmock one as it is - I think the `Net::HTTP` is the one having the most collisions.

Related issue: https://github.com/railsware/http_logger/issues/18