### PR TITLE
Add option to not filter_authorization

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,7 @@ HttpLogger.ignore = [/newrelic\.com/]
 HttpLogger.log_headers = false  # Default: false
 HttpLogger.log_request_body  = false  # Default: true
 HttpLogger.log_response_body = false  # Default: true
+HttpLogger.filter_authorization = false  # Default: true
 HttpLogger.level = :info # Desired log level as a symbol. Default: :debug
 HttpLogger.collapse_body_limit # Change default truncate limit. Default: 5000
 ```

--- a/lib/http_logger.rb
+++ b/lib/http_logger.rb
@@ -29,6 +29,7 @@ class HttpLogger
     attr_accessor :log_headers
     attr_accessor :log_request_body
     attr_accessor :log_response_body
+    attr_accessor :filter_authorization
     attr_accessor :logger
     attr_accessor :colorize
     attr_accessor :ignore
@@ -38,6 +39,7 @@ class HttpLogger
   self.log_headers = false
   self.log_request_body = true
   self.log_response_body = true
+  self.filter_authorization = true
   self.colorize = true
   self.collapse_body_limit = 5000
   self.ignore = []
@@ -91,7 +93,11 @@ class HttpLogger
   end
 
   def log_header(type, name, value)
-    value = "<filtered>" if name == AUTHORIZATION_HEADER
+    if name == AUTHORIZATION_HEADER
+      if self.class.filter_authorization
+        value = "<filtered>"
+      end
+    end
     log("HTTP #{type} header", "#{name}: #{value}")
   end
 

--- a/spec/http_logger_spec.rb
+++ b/spec/http_logger_spec.rb
@@ -57,10 +57,23 @@ describe HttpLogger do
 
     context "authorization header" do
 
+      let(:bearer_token) { "Basic #{Base64.encode64('hello:world')}".strip }
       let(:request_headers) do
-        {'Authorization' => "Basic #{Base64.encode64('hello:world')}".strip}
+        {'Authorization' => bearer_token}
       end
-      it { should include("Authorization: <filtered>") }
+
+      context "filtered" do
+        it { should include("Authorization: <filtered>") }
+      end
+
+      context "not filtered" do
+
+        before(:each) do
+          HttpLogger.filter_authorization = false
+        end
+
+        it { should include("Authorization: #{bearer_token}") }
+      end
     end
 
     after(:each) do


### PR DESCRIPTION
This is helpful when debugging authorization. It defaults to true and won't affect any current instances.