### PR TITLE
Add base64 and logger as development dependencies

### DIFF
--- a/http_logger.gemspec
+++ b/http_logger.gemspec
@@ -21,7 +21,9 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ["LICENSE.txt"]
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "base64"
   spec.add_development_dependency "bundler", ">= 2.0"
+  spec.add_development_dependency "logger"
   spec.add_development_dependency "rake", ">= 13.0"
   spec.add_development_dependency "rspec", ">= 3.0"
   spec.add_development_dependency "webmock", ">= 3.0"


### PR DESCRIPTION
## Summary

- Add `base64` and `logger` as development dependencies to fix failing tests
- Ruby 3.4+ no longer includes these standard library gems by default

## Test plan

- [x] All tests pass: `bundle exec rspec` (22 examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)